### PR TITLE
Adding 'runs' option to execute benchmark and 'samples' in result

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,14 @@ benchmark(callback => fs.readFile('foo.txt', callback))
 
 ## class *BenchmarkResult*
 
-Each benchmark returns an immutable object describing the result of that benchmark. It has five properties:
+Each benchmark returns an immutable object describing the result of that benchmark. It has six properties:
 
 * `mean`, the average measured time in nanoseconds
 * `error`, the margin of error as a ratio of the mean
 * `max`, the fastest measured time in nanoseconds
 * `min`, the slowest measured time in nanoseconds
 * `count`, the number of times the subject was invoked and measured
+* `samples`, current time for all executions of subject in nanoseconds
 
 ### .nanoseconds([*precision*]) -> *number*
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ The combination of these things makes it a highly accurate measuring device. How
 
 # API
 
-## benchmark(*subject*, [*setup*, [*duration*]]) -> *benchmarkResult*
+## benchmark(*subject*, [*setup*, [*duration*, [*runs*]]]) -> *benchmarkResult*
 
 Runs a new benchmark. This measures the performance of the `subject` function. If a `setup` function is provided, it will be invoked before every execution of `subject`.
 
 By default, the benchmark runs for about 3 seconds, but this can be overridden by passing a `duration` number (in milliseconds). Regardless of the desired duration, the benchmark will not finish until the `subject` has been run at least 10 times.
+
+If `runs` number is passed, the benchmark will generate results for the specified executions count of `subject`, ignoring `duration` property.
 
 Both `subject` and `setup` can run asynchronously by declaring a callback argument in their signature. If you do this, you must invoke the callback to indicate that the operation is complete. When running an asyncronous benchmark, this function returns a promise. However, because `subject` and `setup` use callbacks rather than promises, synchronous errors will not automatically be caught.
 

--- a/index.js
+++ b/index.js
@@ -2,15 +2,19 @@
 const benchmark = require('./lib/benchmark');
 const makeAsync = fn => cb => { fn(); cb(); };
 
-module.exports = (fn, setup, duration) => {
+module.exports = (fn, setup, duration, runs = null) => {
 	if (typeof fn !== 'function') throw new TypeError('Expected benchmark subject to be a function');
 	if (setup == null) setup = fn.length ? cb => { cb(); } : () => {};
 	if (duration == null) duration = 3300;
 	if (typeof setup !== 'function') throw new TypeError('Expected benchmark setup to be a function');
 	if (!Number.isInteger(duration)) throw new TypeError('Expected benchmark duration to be an integer');
   if (duration <= 0) throw new TypeError('Expected benchmark duration to be positive');
+	if (duration !== null) {
+		if (!Number.isInteger(duration)) throw new TypeError('Expected benchmark total runs to be an integer');
+		if (duration <= 0) throw new TypeError('Expected benchmark total runs to be positive');
+	}
 	if (!fn.length && !setup.length) return benchmark.sync(fn, setup, duration);
 	if (!fn.length) fn = makeAsync(fn);
 	if (!setup.length) setup = makeAsync(setup);
-	return benchmark.async(fn, setup, duration);
+	return benchmark.async(fn, setup, duration, runs);
 };

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = (fn, setup, duration, runs = null) => {
 		if (!Number.isInteger(duration)) throw new TypeError('Expected benchmark total runs to be an integer');
 		if (duration <= 0) throw new TypeError('Expected benchmark total runs to be positive');
 	}
-	if (!fn.length && !setup.length) return benchmark.sync(fn, setup, duration);
+	if (!fn.length && !setup.length) return benchmark.sync(fn, setup, duration, runs);
 	if (!fn.length) fn = makeAsync(fn);
 	if (!setup.length) setup = makeAsync(setup);
 	return benchmark.async(fn, setup, duration, runs);

--- a/index.js
+++ b/index.js
@@ -9,9 +9,9 @@ module.exports = (fn, setup, duration, runs = null) => {
 	if (typeof setup !== 'function') throw new TypeError('Expected benchmark setup to be a function');
 	if (!Number.isInteger(duration)) throw new TypeError('Expected benchmark duration to be an integer');
   if (duration <= 0) throw new TypeError('Expected benchmark duration to be positive');
-	if (duration !== null) {
-		if (!Number.isInteger(duration)) throw new TypeError('Expected benchmark total runs to be an integer');
-		if (duration <= 0) throw new TypeError('Expected benchmark total runs to be positive');
+	if (runs !== null) {
+		if (!Number.isInteger(runs)) throw new TypeError('Expected benchmark total runs to be an integer');
+		if (runs <= 0) throw new TypeError('Expected benchmark total runs to be positive');
 	}
 	if (!fn.length && !setup.length) return benchmark.sync(fn, setup, duration, runs);
 	if (!fn.length) fn = makeAsync(fn);

--- a/lib/benchmark.js
+++ b/lib/benchmark.js
@@ -3,11 +3,25 @@ const Result = require('./result');
 const async = require('./async');
 const sync = require('./sync');
 
-exports.sync = (fn, setup, duration) => {
+/**
+ * Validates and return actual value to be used for "runs" property.
+ */
+const extractRunsValue = runs => {
+	runs = runs && Number(runs);
+	if (runs && (isNaN(runs) || runs <= 0)) throw new TypeError('Specified count of runs must be a positive number.');
+	return runs;
+};
+
+exports.sync = (fn, setup, duration, runs) => {
 	const allSamples = [];
 	let totalCount = 0;
 	duration += Date.now();
-	
+	runs = extractRunsValue(runs);
+
+	const continueToRun = runs ?
+		() => totalCount < runs :
+		() => Date.now() < duration;
+
 	// We measure in chunks of 100ms to periodically work the garbage collector.
 	// This acts like a "dither" to smooth out the fluctuating memory usage caused
 	// by the benchmarking engine itself (https://en.wikipedia.org/wiki/Dither).
@@ -16,26 +30,31 @@ exports.sync = (fn, setup, duration) => {
 		const samples = sync(fn, setup, 100); // Actual benchmark
 		allSamples.push(samples);
 		totalCount += samples.length;
-	} while (Date.now() < duration || totalCount < 10)
-	
-	return new Result([].concat(...allSamples));
+	} while (continueToRun() || totalCount < 10)
+
+	return new Result([].concat(...allSamples), runs);
 };
 
-exports.async = (fn, setup, duration) => {
+exports.async = (fn, setup, duration, runs) => {
 	const allSamples = [];
 	let totalCount = 0;
 	duration += Date.now();
-	
+	runs = extractRunsValue(runs);
+
+	const continueToRun = runs ?
+		() => totalCount < runs :
+		() => Date.now() < duration;
+
 	// Here we do the same thing as commented in sync().
 	const dither = () => async(cb => { cb(); }, cb => { cb(); }, 10);
 	const actual = () => async(fn, setup, 100);
 	const loop = (samples) => {
 		allSamples.push(samples);
 		totalCount += samples.length;
-		if (Date.now() < duration || totalCount < 10) return dither().then(actual).then(loop);
-		return new Result([].concat(...allSamples));
+		if (continueToRun() || totalCount < 10) return dither().then(actual).then(loop);
+		return new Result([].concat(...allSamples), runs);
 	};
-	
+
 	return dither().then(actual).then(loop);
 };
 

--- a/lib/benchmark.js
+++ b/lib/benchmark.js
@@ -3,13 +3,10 @@ const Result = require('./result');
 const async = require('./async');
 const sync = require('./sync');
 
-/**
- * Validates and return actual value to be used for "runs" property.
- */
 const extractRunsValue = runs => {
-	runs = runs && Number(runs);
-	if (runs && (isNaN(runs) || runs <= 0)) throw new TypeError('Specified count of runs must be a positive number.');
-	return runs;
+	if (runs !== null) 
+		return runs + 5;
+	return null;
 };
 
 exports.sync = (fn, setup, duration, runs) => {

--- a/lib/result.js
+++ b/lib/result.js
@@ -11,7 +11,8 @@ class BenchmarkResult {
 	constructor(samples, runs) {
 		samples.splice(0, 5); // Remove samples gathered before v8 optimization
 		if (runs) {
-			samples.splice(runs, samples.length - runs);
+			// removing the offset "5" added before
+			samples.splice(runs, samples.length - (runs - 5));
 		}
 		
 		this.mean = getMean(samples);

--- a/lib/result.js
+++ b/lib/result.js
@@ -12,7 +12,7 @@ class BenchmarkResult {
 		samples.splice(0, 5); // Remove samples gathered before v8 optimization
 		if (runs) {
 			// removing the offset "5" added before
-			samples.splice(runs, samples.length - (runs - 5));
+			samples.splice(runs - 5, samples.length - (runs - 5));
 		}
 		
 		this.mean = getMean(samples);

--- a/lib/result.js
+++ b/lib/result.js
@@ -8,13 +8,18 @@ const getMean = arr => arr.reduce(fSum, 0) / arr.length;
 const getMgnError = (arr, mean) => Math.sqrt(arr.reduce(fSumSqDiff(mean), 0)) / arr.length * 2;
 
 class BenchmarkResult {
-	constructor(samples) {
+	constructor(samples, runs) {
 		samples.splice(0, 5); // Remove samples gathered before v8 optimization
+		if (runs) {
+			samples.splice(runs, samples.length - runs);
+		}
+		
 		this.mean = getMean(samples);
 		this.error = getMgnError(samples, this.mean) / this.mean;
 		this.max = Math.max(0, samples.reduce(fMax));
 		this.min = Math.max(0, samples.reduce(fMin));
 		this.count = samples.length;
+		this.samples = samples;
 		if (!(this.mean >= 10)) this.mean = this.error = this.max = this.min = NaN;
 		Object.freeze(this);
 	}


### PR DESCRIPTION
Hi, Joshua

This PR is adding another mode of execution for the benchmark, instead of using only the maximum duration option. I think it's relevant for benchmarks betweens different implementations, so all subjects may have the same amount of runs to be tested, not gaining or losing an advantage with different total runs executed.

Also adding the 'samples' property to result, so it makes possible to generate graphs like a boxplot from benchmarks.

I'm currently using your lib in my CompSci Undergraduate Thesis, where I'm benchmarking three different cache libraries and writing about it, and needed these changes. I thought they may be relevant to others. Thanks for your work! :)